### PR TITLE
fix: add min node engine requirement to support mandatory es6 requirement by mongodb 6 package

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "waterline-adapter-tests": "^1.0.1",
     "waterline-utils": "^1.4.2"
   },
+  "engines": {
+    "node": ">=16.20.1"
+  },
   "waterlineAdapter": {
     "interfaces": [
       "semantic",


### PR DESCRIPTION
This is needed to unblock mongodb node driver upgrade to v6 which has min. version req. of node to be v16. [reference](https://github.com/mongodb/node-mongodb-native/blob/HEAD/etc/notes/CHANGES_6.0.0.md)